### PR TITLE
dockerise

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,35 @@
+name: Build and Push
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN dotnet restore
 COPY img.birb.cc/. ./img.birb.cc/
 WORKDIR /source/img.birb.cc
 RUN dotnet publish -c release -o /app --no-restore --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true
+RUN mkdir /app/config /app/uploads && chown -R $APP_UID /app/config /app/uploads
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /source
+
+COPY *.sln .
+COPY img.birb.cc/*.csproj ./img.birb.cc/
+RUN dotnet restore
+
+COPY img.birb.cc/. ./img.birb.cc/
+WORKDIR /source/img.birb.cc
+RUN dotnet publish -c release -o /app --no-restore --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true
+
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled
+WORKDIR /app
+COPY --from=build /app ./
+
+ENV ASPNETCORE_HTTP_PORTS=5000
+ENV CONFIG_PATH=/app/config
+ENV SALT_PATH=/app/config/salt.txt
+ENV UPLOADS_PATH=/app/uploads
+
+VOLUME /app/config
+VOLUME /app/uploads
+
+ENTRYPOINT ["/app/img.birb.cc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet restore
 COPY img.birb.cc/. ./img.birb.cc/
 WORKDIR /source/img.birb.cc
 RUN dotnet publish -c release -o /app --no-restore --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true
-RUN mkdir /app/config /app/uploads && chown -R $APP_UID /app/config /app/uploads
+RUN mkdir /app/config /app/uploads && chown -R $APP_UID /app
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-noble-chiseled
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ ENV UPLOADS_PATH=/app/uploads
 VOLUME /app/config
 VOLUME /app/uploads
 
+EXPOSE 5000
+
 ENTRYPOINT ["/app/img.birb.cc"]

--- a/img.birb.cc/Program.cs
+++ b/img.birb.cc/Program.cs
@@ -30,10 +30,13 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
 
 app.UseDefaultFiles();      // use index.html & index.css
 app.UseStaticFiles();       // enable static file serving
-app.UseStaticFiles(new StaticFileOptions
+if (Config.UploadsPath != "wwwroot")
 {
-    FileProvider = new PhysicalFileProvider(Config.UploadsPath)
-});
+    app.UseStaticFiles(new StaticFileOptions
+    {
+        FileProvider = new PhysicalFileProvider(Config.UploadsPath)
+    });
+}
 app.UseCors(MyAllowSpecificOrigins);
 
 app.MapPost("/api/img", async Task<IResult> (HttpRequest request) => // get your uploaded files

--- a/img.birb.cc/Program.cs
+++ b/img.birb.cc/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.FileProviders;
 using System.Text.RegularExpressions;
 
 // TODO:
@@ -27,9 +28,12 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 });
 
-app.UseHttpsRedirection();  // redirect 80 to 443
 app.UseDefaultFiles();      // use index.html & index.css
 app.UseStaticFiles();       // enable static file serving
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(Config.UploadsPath)
+});
 app.UseCors(MyAllowSpecificOrigins);
 
 app.MapPost("/api/img", async Task<IResult> (HttpRequest request) => // get your uploaded files
@@ -222,8 +226,8 @@ app.MapGet("/api/stats", async () => // get host stats
     stats.Files = FileDB.GetDB().Count;
     stats.Users = UserDB.GetDB().Count;
 
-    // iterate through every file in wwwroot, ignoring .* and *.html and favicon - then sum filesize.
-    DirectoryInfo dirInfo = new DirectoryInfo(@"wwwroot/");
+    // iterate through every file in uploads, ignoring .* and *.html and favicon - then sum filesize.
+    DirectoryInfo dirInfo = new DirectoryInfo(Config.UploadsPath);
     stats.Bytes = await Task.Run(() => dirInfo.EnumerateFiles("*", SearchOption.TopDirectoryOnly).Where(file => file.Extension != ".html" && !file.Name.StartsWith(".") && file.Name != "favicon.png").Sum(file => file.Length));
 
     // get timestamp of latest uploaded file
@@ -282,7 +286,7 @@ app.MapPost("/api/upload", async (http) => // upload file
 
     Img newFile = new Img().NewImg(user.UID, extension, img);
 
-    using (var filestream = System.IO.File.Create("wwwroot/" + newFile.Filename))
+    using (var filestream = System.IO.File.Create(Path.Join(Config.UploadsPath, newFile.Filename)))
     {
         stream.Position = 0;
         stream.CopyTo(filestream);

--- a/img.birb.cc/config.cs
+++ b/img.birb.cc/config.cs
@@ -18,12 +18,15 @@ public class Settings
 
 public static class Config
 {
-    private const string path = "config.json";
+    public static string UploadsPath = Environment.GetEnvironmentVariable("UPLOADS_PATH") ?? "wwwroot";
+
+    private static string configDirectory = Environment.GetEnvironmentVariable("CONFIG_PATH") ?? "";
+    private static string path = Path.Join(configDirectory, "config.json");
 
     public static string? DefaultDomain { get; private set; } = "img.birb.cc";
-    public static string? UserDBPath { get; private set; } = "user.json";
-    public static string? FileDBPath { get; private set; } = "img.json";
-    public static string? LogPath { get; private set; } = "logs";
+    public static string? UserDBPath { get; private set; } = Path.Join(configDirectory, "user.json");
+    public static string? FileDBPath { get; private set; } = Path.Join(configDirectory, "img.json");
+    public static string? LogPath { get; private set; } = Path.Join(configDirectory, "logs");
     public static bool LoggingEnabled { get; private set; } = false;
 
     public static List<String>? AllowedFileTypes { get; private set; } = new List<String>() {

--- a/img.birb.cc/hashing.cs
+++ b/img.birb.cc/hashing.cs
@@ -7,9 +7,10 @@ public static class Hashing
 
     public static void LoadSalt()
     {
+        var saltPath = Environment.GetEnvironmentVariable("SALT_PATH") ?? "salt.txt";
         try
         {
-            using (StreamReader SR = new StreamReader("salt.txt"))
+            using (StreamReader SR = new StreamReader(saltPath))
             {
                 salt = SR.ReadToEnd().Trim();
             }
@@ -20,10 +21,10 @@ public static class Hashing
             Log.Warning($"Unable to load salt");
         }
 
-        if (!File.Exists("salt.txt") || string.IsNullOrEmpty(salt))
+        if (!File.Exists(saltPath) || string.IsNullOrEmpty(salt))
         {
             Log.Info("Generating new salt. Keep this safe!!!");
-            using (StreamWriter SW = new StreamWriter("salt.txt"))
+            using (StreamWriter SW = new StreamWriter(saltPath))
             {
                 salt = NewHash(40);
                 SW.WriteLine(salt);

--- a/img.birb.cc/img.birb.cc.csproj
+++ b/img.birb.cc/img.birb.cc.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='release'">

--- a/img.birb.cc/img.cs
+++ b/img.birb.cc/img.cs
@@ -151,7 +151,7 @@ public static class FileDB
         db.Remove(file);
         Save();
 
-        File.Delete("wwwroot/" + file.Filename);
+        File.Delete(Path.Join(Config.UploadsPath, file.Filename));
         Log.Info("Removed file " + file.Filename);
     }
 
@@ -162,7 +162,7 @@ public static class FileDB
         foreach (Img img in images.Where(img => img.UID == user.UID))
         {
             db.Remove(img);
-            File.Delete("wwwroot/" + img.Filename);
+            File.Delete(Path.Join(Config.UploadsPath, img.Filename));
         }
         Log.Info($"nuked {user.Username}");
         Save();

--- a/img.birb.cc/wwwroot/js/admin.js
+++ b/img.birb.cc/wwwroot/js/admin.js
@@ -9,7 +9,7 @@ async function login() {
     let formData = new FormData();
     formData.append("api_key", document.getElementById("keybox").value)
 
-    fetch(`https://${url}/api/users`,
+    fetch(`/api/users`,
         {
             body: formData,
             method: "post"
@@ -35,7 +35,7 @@ async function getimgs(uid) {
 
     let imgs;
 
-    await fetch(`https://${url}/api/img`,
+    await fetch(`/api/img`,
         {
             body: formData,
             method: "post"
@@ -122,7 +122,7 @@ async function newuser(name, uid) {
 
     let token;
 
-    await fetch(`https://${url}/api/usr/new`,
+    await fetch(`/api/usr/new`,
         {
             body: formData,
             method: "post"

--- a/img.birb.cc/wwwroot/js/dashboard.js
+++ b/img.birb.cc/wwwroot/js/dashboard.js
@@ -11,7 +11,7 @@ async function login() {
     let formData = new FormData();
     formData.append("api_key", document.getElementById("keybox").value)
 
-    fetch(`https://${url}/api/usr`,
+    fetch(`/api/usr`,
         {
             body: formData,
             method: "post"
@@ -51,7 +51,7 @@ async function definitelyNuke() {
     let formData = new FormData();
     formData.append("api_key", document.getElementById("keybox").value)
 
-    fetch(`https://${url}/api/nuke`,
+    fetch(`/api/nuke`,
         {
             body: formData,
             method: "DELETE"
@@ -80,7 +80,7 @@ function displayPage(x) {
 
     for (var i = (pagecount - 1) * pagelength; i < length; i++) {
         var item = imgout[imgout.length - i - 1]["filename"].endsWith(".mp4") ? document.createElement("video") : document.createElement("img");
-        item.src = `https://${url}/` + imgout[imgout.length - i - 1]["filename"]
+        item.src = '/' + imgout[imgout.length - i - 1]["filename"]
         item.setAttribute("onclick", `display("${imgout[imgout.length - i - 1]["filename"]}","${imgout[imgout.length - i - 1]["timestamp"]}")`)
         document.getElementById("images").appendChild(item)
     }
@@ -90,7 +90,7 @@ function loadImages() {
     let formData = new FormData();
     formData.append("api_key", document.getElementById("keybox").value)
 
-    fetch(`https://${url}/api/img`,
+    fetch(`/api/img`,
         {
             body: formData,
             method: "post"
@@ -100,7 +100,9 @@ function loadImages() {
                 imgout = data
                 document.getElementById("files").innerHTML = usrout["uploadCount"] + " files uploaded"
                 document.getElementById("gb").innerHTML = bytes(usrout["uploadedBytes"]) + " uploaded"
-                document.getElementById("time").innerHTML = changeToTime(Math.round((new Date().getTime() - Date.parse(data[data.length - 1]["timestamp"])) / 1000 / 60)) + " since last upload"
+                if (data.length > 0) {
+                    document.getElementById("time").innerHTML = changeToTime(Math.round((new Date().getTime() - Date.parse(data[data.length - 1]["timestamp"])) / 1000 / 60)) + " since last upload"
+                }
 
                 displayPage()
             })
@@ -116,7 +118,7 @@ async function submitSettings() {
         formData.append("stripEXIF", document.getElementById("stripEXIF").checked)
         formData.append("dashMsg", document.getElementById("feedback").value)
 
-        fetch(`https://${url}/api/usr/settings`,
+        fetch(`/api/usr/settings`,
             {
                 body: formData,
                 method: "POST"
@@ -138,7 +140,7 @@ async function delimg(hash) {
     let formData = new FormData();
     formData.append("api_key", document.getElementById("keybox").value)
 
-    fetch(`https://${url}/api/delete/${hash}`,
+    fetch(`/api/delete/${hash}`,
         {
             body: formData,
             method: "DELETE"
@@ -167,12 +169,12 @@ function display(filename, timestamp) {
     document.getElementById("copyurl").setAttribute("onclick", "copyToClipboard(" + `"${(document.getElementById("showURL").checked ? "​" : "")}https://${url}/${filename}")`)
 
     if (filename.endsWith(".mp4")) {
-        document.getElementById("preview_vid").src = `https://${url}/` + filename
+        document.getElementById("preview_vid").src = '/' + filename
         document.getElementById("preview_vid").style.display = "initial"
         document.getElementById("preview_img").style.display = "none"
     }
     else {
-        document.getElementById("preview_img").src = `https://${url}/` + filename
+        document.getElementById("preview_img").src = '/' + filename
         document.getElementById("preview_img").style.display = "initial"
         document.getElementById("preview_vid").style.display = "none"
     }
@@ -272,7 +274,7 @@ document.getElementById("upload").addEventListener('change', async function () {
         formData.append("api_key", document.getElementById("keybox").value)
         formData.append("img", this.files[0])
 
-        fetch(`https://${url}/api/upload`,
+        fetch(`/api/upload`,
             {
                 body: formData,
                 method: "POST"


### PR DESCRIPTION
My goal here was to dockerise the project without messing with your code much and making sure it works the same way as before if ran without Docker. I think I kinda failed both (see ❗️ below), so merge with caution.

- removed absolute URLs from the frontend where possible. this way it was just easier to test without https
- separated uploads from wwwroot (resorts to old `wwwroot` behaviour by default)
- separated configs from workdir (resorts to using workdir by default)
- removed http->https redirect as this is something your balancer should do (❗️you might have to adjust the nginx config)
- bumped .net target to 8 (❗️you might have to add `ASPNETCORE_HTTP_PORTS=5000` in your systemd unit to run without Docker)
- added multi-stage Dockerfile
- added Github CI

Spinning it up in Docker without traefik should be pretty easy:
```yaml
version: '3.7'
services:
  app:
    image: ghcr.io/hummusbird/img.birb.cc
    restart: always
    ports:
      - 12111:5000
    volumes:
      - uploads:/app/uploads
      - config:/app/config
    labels:
      com.centurylinklabs.watchtower.enable: 'true'
volumes:
  config:
  uploads:
```
